### PR TITLE
feat: support error result with only message

### DIFF
--- a/Mimiware.ServiceResult/Mimiware.ServiceResult.Tests/ServiceResultErrorTests.cs
+++ b/Mimiware.ServiceResult/Mimiware.ServiceResult.Tests/ServiceResultErrorTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Xunit;
+﻿using Xunit;
 
 namespace Mimiware.ServiceResult.Tests
 {

--- a/Mimiware.ServiceResult/Mimiware.ServiceResult.Tests/ServiceResultTests.cs
+++ b/Mimiware.ServiceResult/Mimiware.ServiceResult.Tests/ServiceResultTests.cs
@@ -110,7 +110,6 @@ namespace Mimiware.ServiceResult.Tests
             Assert.Equal(isSuccessCode, result.IsSuccessCode);
         }
 
-
         /// <summary>
         /// 
         /// </summary>
@@ -128,8 +127,28 @@ namespace Mimiware.ServiceResult.Tests
             yield return new object[] { ServiceResultCode.NotFound, false };
             yield return new object[] { ServiceResultCode.ServiceUnavailable, false };
             yield return new object[] { ServiceResultCode.UnAuthorized, false };
+        }
 
+        [Fact]
+        public void ServiceResultError_TypedResult_WithMessage()
+        {
+            IServiceResult<object> result = new ServiceResult<object>();
 
+            const string message = "Failed to get Id";
+            var errorResult = result.Error(message);
+
+            Assert.Equal(message, errorResult.ErrorMessage.ErrorMessage);
+        }
+
+        [Fact]
+        public void ServiceResultError_TypedResult_WithoutParameters()
+        {
+            IServiceResult<object> result = new ServiceResult<object>();
+
+            var errorResult = result.Error();
+
+            Assert.Equal(ServiceResultCode.InternalError, errorResult.Code);
+            Assert.Null(errorResult?.ErrorMessage.ErrorMessage);
         }
     }
 }

--- a/Mimiware.ServiceResult/Mimiware.ServiceResult/Mimiware.ServiceResult.csproj
+++ b/Mimiware.ServiceResult/Mimiware.ServiceResult/Mimiware.ServiceResult.csproj
@@ -10,8 +10,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.0</Version>
-    <PackageReleaseNotes>Added more service result codes.</PackageReleaseNotes>
+    <Version>1.3.0</Version>
+    <PackageReleaseNotes>Contains more improvements.</PackageReleaseNotes>
   </PropertyGroup>
 
 </Project>

--- a/Mimiware.ServiceResult/Mimiware.ServiceResult/ServiceResult.cs
+++ b/Mimiware.ServiceResult/Mimiware.ServiceResult/ServiceResult.cs
@@ -28,6 +28,9 @@
         IServiceResult<T> Error(
             int code = ServiceResultCode.InternalError,
             string message = null);
+
+        IServiceResult<T> Error(
+            string message);
     }
 
     /// <inheritdoc cref="IServiceResult{T}"/>
@@ -50,6 +53,16 @@
             return new ServiceResult<T>
             {
                 Code = code,
+                ErrorMessage = new ServiceResultError(message)
+            };
+        }
+
+        public IServiceResult<T> Error(
+            string message)
+        {
+            return new ServiceResult<T>
+            {
+                Code = ServiceResultCode.InternalError,
                 ErrorMessage = new ServiceResultError(message)
             };
         }


### PR DESCRIPTION
Makes it possible to skip typing result.Error(message: message);.